### PR TITLE
Added support for strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 .idea
 .ccls-cache
 test_scripts
+CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ set(C_LINK_FLAGS)
 list(APPEND C_COMPILE_FLAGS -Wall -Wextra -pedantic)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-    list(APPEND C_COMPILE_FLAGS -fno-omit-frame-pointer
-            -fno-optimize-sibling-calls -fsanitize=address)
+    list(APPEND C_COMPILE_FLAGS -fsanitize=address -fno-omit-frame-pointer
+            -fno-optimize-sibling-calls )
     list(APPEND C_LINK_FLAGS -fsanitize=address -fno-omit-frame-pointer
             -fno-optimize-sibling-calls)
     target_compile_definitions(clox PRIVATE DEBUG_PRINT_CODE)

--- a/include/memory.h
+++ b/include/memory.h
@@ -5,18 +5,21 @@
 
 /* === Memory management === */
 
-//#define GROW_CAPACITY(capacity) \
-//    ((capacity) < 8 ? 8 : (capacity) * 2)
-//
-//#define GROW_ARRAY(type, pointer, old_count, new_count) \
-//    (type*)mem_reallocate(pointer, sizeof(type) * (old_count), \
-//                      sizeof(type) * (new_count))
-//
-//#define FREE_ARRAY(type, pointer, old_count) \
-//    mem_reallocate(pointer, sizeof(type) * (old_count), 0)
+#define GROW_CAPACITY(capacity) ((capacity) < 8 ? 8 : (capacity)*2)
 
-//void* mem_reallocate(void* pointer, size_t old_size, size_t new_size);
+#define GROW_ARRAY(type, pointer, old_count, new_count) \
+    (type*)mem_reallocate(pointer, sizeof(type) * (old_count), sizeof(type) * (new_count))
+
+#define FREE_ARRAY(type, pointer, old_count) \
+    mem_reallocate(pointer, sizeof(type) * (old_count), 0)
+
+#define ALLOCATE(type, length) (type*)mem_reallocate(NULL, 0, sizeof(type) * (length))
+
+#define FREE(type, pointer) mem_reallocate(pointer, sizeof(type), 0)
+
+void* mem_reallocate(void* pointer, size_t old_size, size_t new_size);
+void free_objects();
 
 /* === Memory management === */
 
-#endif // MEMORY_H
+#endif  // MEMORY_H

--- a/include/object.h
+++ b/include/object.h
@@ -1,0 +1,42 @@
+#ifndef OBJECT_H
+#define OBJECT_H
+
+#include "common.h"
+#include "value.h"
+
+typedef enum
+{
+    OBJ_STRING,
+} ObjectType;
+
+struct Obj
+{
+    ObjectType type;
+    struct Obj* next;
+};
+
+struct ObjString
+{
+    Obj obj;
+    int length;
+    bool is_owning;  // Does it own its characters.
+    char* chars;
+};
+
+#define OBJ_TYPE(value) (AS_OBJ(value)->type)
+#define IS_STRING(value) is_obj_type(value, OBJ_STRING)
+#define AS_STRING(value) ((ObjString*)AS_OBJ(value))
+#define AS_CSTRING(value) (((ObjString*)AS_OBJ(value))->chars)
+
+static inline bool is_obj_type(Value value, ObjectType type)
+{
+    return IS_OBJ(value) && AS_OBJ(value)->type == type;
+}
+
+// Creates a string that owns its chars.
+ObjString* vle_owning_string(char* chars, int length);
+// Creates non-owning string that points into the source code.
+ObjString* vle_constant_string(char* chars, int length);
+void vle_print_object(Value value);
+
+#endif  // OBJECT_H

--- a/include/value.h
+++ b/include/value.h
@@ -4,11 +4,15 @@
 #include "common.h"
 #include "vec.h"
 
+typedef struct Obj Obj;
+typedef struct ObjString ObjString;
+
 typedef enum
 {
     VAL_BOOL,
     VAL_NIL,
-    VAL_NUMBER
+    VAL_NUMBER,
+    VAL_OBJ,
 } ValueType;
 
 typedef struct
@@ -18,6 +22,7 @@ typedef struct
     {
         bool boolean;
         double number;
+        Obj* obj;
     } as;
 } Value;
 
@@ -26,20 +31,25 @@ typedef vec_t(Value) vec_val_t;
 /* === Runtime values manipulation === */
 
 // clang-format off
-#define NIL_VAL ((Value){.type = VAL_NIL, .as.number = 0})
-#define BOOL_VAL(value) ((Value){.type = VAL_BOOL, .as.boolean = value})
+#define NIL_VAL             ((Value){.type = VAL_NIL, .as.number = 0})
+#define BOOL_VAL(value)    ((Value){.type = VAL_BOOL, .as.boolean = value})
 #define NUMBER_VAL(value) ((Value){.type = VAL_NUMBER, .as.number = value})
+#define OBJ_VAL(object)    ((Value){.type = VAL_OBJ, .as.obj = (Obj*)object})
 
-#define AS_BOOL(value) ((value).as.boolean)
-#define AS_NUMBER(value) ((value).as.number)
+#define AS_BOOL(value)      ((value).as.boolean)
+#define AS_NUMBER(value)   ((value).as.number)
+#define AS_OBJ(value)       ((value).as.obj)
 
-#define IS_NIL(value) ((value).type == VAL_NIL)
-#define IS_BOOL(value) ((value).type == VAL_BOOL)
-#define IS_NUMBER(value) ((value).type == VAL_NUMBER)
+#define IS_NIL(value)       ((value).type == VAL_NIL)
+#define IS_BOOL(value)      ((value).type == VAL_BOOL)
+#define IS_NUMBER(value)   ((value).type == VAL_NUMBER)
+#define IS_OBJ(value)       ((value).type == VAL_OBJ)
 
 // clang-format on
 
 void vle_print_value(Value value);
+bool vle_is_false(Value value);
+bool vle_is_equal(Value a, Value b);
 
 /* === Runtime values manipulation === */
 

--- a/include/vm.h
+++ b/include/vm.h
@@ -10,6 +10,8 @@ typedef struct
     Chunk* chunk;
     uint8_t* ip;
     vec_val_t stack;
+
+    Obj* objects;
 } Vm;
 
 typedef enum
@@ -18,6 +20,8 @@ typedef enum
     INTPR_COMPILE_ERROR,
     INTPR_RUNTIME_ERROR
 } InterpreterResult;
+
+extern Vm g_vm;
 
 void vm_init_vm();
 InterpreterResult vm_interpret(const char* source);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,2 @@
-target_sources(clox PRIVATE main.c chunk.c memory.c error.c debug.c value.c vec.c vm.c compiler.c scanner.c)
+target_sources(clox PRIVATE main.c chunk.c memory.c error.c debug.c
+        value.c vec.c vm.c compiler.c scanner.c object.c)

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -4,6 +4,7 @@
 #ifdef DEBUG_PRINT_CODE
 #include "debug.h"
 #endif
+#include "object.h"
 
 Parser g_parser;
 Chunk* compiling_chunk;
@@ -30,6 +31,7 @@ static void grouping();
 static void unary();
 static void binary();
 static void literal();
+static void string();
 
 // Parse any expression at the given precedence level.
 static void parse_precedence(Precedence precedence);
@@ -61,7 +63,7 @@ ParseRule g_rules[] = {
     [TOKEN_LESS]          = {NULL,     binary,   PREC_COMPARISON},
     [TOKEN_LESS_EQUAL]    = {NULL,     binary,   PREC_COMPARISON},
     [TOKEN_IDENTIFIER]    = {NULL,     NULL,   PREC_NONE},
-    [TOKEN_STRING]        = {NULL,     NULL,   PREC_NONE},
+    [TOKEN_STRING]        = {string,     NULL,   PREC_NONE},
     [TOKEN_NUMBER]        = {number,   NULL,   PREC_NONE},
     [TOKEN_AND]           = {NULL,     NULL,   PREC_NONE},
     [TOKEN_CLASS]         = {NULL,     NULL,   PREC_NONE},
@@ -274,6 +276,12 @@ static void literal()
         default:
             DEBUG_ERROR("Not every case was handled.");
     }
+}
+
+static void string()
+{
+    emit_constant(OBJ_VAL(
+        vle_constant_string(g_parser.previous.start + 1, g_parser.previous.length - 2)));
 }
 
 static void parse_precedence(Precedence precedence)

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,24 +1,53 @@
 #include <stdlib.h>
 
+#include "object.h"
+#include "vm.h"
 #include "error.h"
 #include "memory.h"
 
-// This function is the only one used for dynamic memory management in clox.
-// void* mem_reallocate(void* pointer, size_t old_size, size_t new_size)
-//{
-//    if (new_size == 0)
-//    {
-//        free(pointer);
-//        return NULL;
-//    }
-//
-//    void* result = realloc(pointer, new_size);
-//    if (result == NULL)
-//    {
-//        DEBUG_ERROR("Failed to allocate memory.");
-//        free(result);
-//        exit(1);
-//    }
-//
-//    return result;
-//}
+static void free_object(Obj* object);
+
+void* mem_reallocate(void* pointer, size_t old_size, size_t new_size)
+{
+    if (new_size == 0)
+    {
+        free(pointer);
+        return NULL;
+    }
+
+    void* result = realloc(pointer, new_size);
+    if (result == NULL)
+    {
+        free(result);
+        DEBUG_ERROR("Failed to allocate memory.");
+    }
+
+    return result;
+}
+
+void free_objects()
+{
+    Obj* object = g_vm.objects;
+    while (object != NULL)
+    {
+        Obj* next = object->next;
+        free_object(object);
+        object = next;
+    }
+}
+
+static void free_object(Obj* object)
+{
+    switch (object->type)
+    {
+        case OBJ_STRING:
+        {
+            ObjString* str = (ObjString*)object;
+            if (!str->is_owning)
+                break;
+            FREE_ARRAY(char, str->chars, str->length + 1);
+            FREE(ObjString, object);
+            break;
+        }
+    }
+}

--- a/src/object.c
+++ b/src/object.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+
+#include "vm.h"
+#include "error.h"
+#include "object.h"
+#include "memory.h"
+
+#define ALLOCATE_OBJ(type, object_type) (type*)allocate_object(sizeof(type), object_type)
+
+static ObjString* allocate_string(char* chars, int length, bool is_owning);
+static Obj* allocate_object(size_t size, ObjectType type);
+
+ObjString* vle_owning_string(char* chars, int length)
+{
+    return allocate_string(chars, length, true);
+}
+
+ObjString* vle_constant_string(char* chars, int length)
+{
+    // char* heap_chars = ALLOCATE(char, length + 1);
+    // memcpy(heap_chars, chars, length);
+    // heap_chars[length] = '\0';
+    return allocate_string(chars, length, false);
+}
+
+static ObjString* allocate_string(char* chars, int length, bool is_owning)
+{
+    ObjString* string = ALLOCATE_OBJ(ObjString, OBJ_STRING);
+    string->length = length;
+    string->chars = chars;
+    string->is_owning = is_owning;
+    return string;
+}
+
+static Obj* allocate_object(size_t size, ObjectType type)
+{
+    Obj* object = (Obj*)mem_reallocate(NULL, 0, size);
+    object->type = type;
+    object->next = g_vm.objects;
+
+    g_vm.objects = object;
+    return object;
+}
+
+void vle_print_object(Value value)
+{
+    switch (OBJ_TYPE(value))
+    {
+        case OBJ_STRING:
+        {
+            ObjString* str = AS_STRING(value);
+            for (int i = 0; i < str->length; i++)
+            {
+                printf("%c", str->chars[i]);
+            }
+            break;
+        }
+        default:
+            DEBUG_ERROR("Not every case was handled.");
+    }
+}

--- a/src/value.c
+++ b/src/value.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 
 #include "value.h"
+#include "object.h"
 #include "error.h"
 
 void vle_print_value(Value value)
@@ -16,7 +17,40 @@ void vle_print_value(Value value)
         case VAL_NIL:
             printf("nil");
             break;
+        case VAL_OBJ:
+            vle_print_object(value);
+            break;
         default:
             DEBUG_ERROR("Not every error case was handled.");
+    }
+}
+
+bool vle_is_false(Value value)
+{
+    return IS_NIL(value) || (IS_BOOL(value) && !AS_BOOL(value));
+}
+
+bool vle_is_equal(Value a, Value b)
+{
+    if (a.type != b.type)
+        return false;
+
+    switch (a.type)
+    {
+        case VAL_BOOL:
+            return AS_BOOL(a) == AS_BOOL(b);
+        case VAL_NUMBER:
+            return AS_NUMBER(a) == AS_NUMBER(b);
+        case VAL_NIL:
+            return true;
+        case VAL_OBJ:
+        {
+            ObjString* a_str = AS_STRING(a);
+            ObjString* b_str = AS_STRING(b);
+            return a_str->length == b_str->length &&
+                   memcmp(a_str, b_str, a_str->length) == 0;
+        }
+        default:
+            DEBUG_ERROR("Not every case was handled.");
     }
 }


### PR DESCRIPTION
`clox` can now recognize strings, print them, compare their equality and
concatenate them.
Added new memory management macros for working with heap-allocated
objects (strings as of this commit).
Moved `is_false()`, `is_equal()` to `value.c`.