### PR TITLE
Added hash tables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,9 @@ set(C_LINK_FLAGS)
 list(APPEND C_COMPILE_FLAGS -Wall -Wextra -pedantic)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-    list(APPEND C_COMPILE_FLAGS -fsanitize=address -fno-omit-frame-pointer
+    list(APPEND C_COMPILE_FLAGS -fno-omit-frame-pointer
             -fno-optimize-sibling-calls )
-    list(APPEND C_LINK_FLAGS -fsanitize=address -fno-omit-frame-pointer
+    list(APPEND C_LINK_FLAGS -fno-omit-frame-pointer
             -fno-optimize-sibling-calls)
     target_compile_definitions(clox PRIVATE DEBUG_PRINT_CODE)
 #    target_compile_definitions(clox PRIVATE DEBUG_TRACE_EXECUTION)

--- a/include/hash_table.h
+++ b/include/hash_table.h
@@ -1,0 +1,29 @@
+#ifndef HASH_TABLE_OPEN_H
+#define HASH_TABLE_OPEN_H
+
+#include "value.h"
+#include "object.h"
+
+typedef struct
+{
+    Value value;
+    ObjString* key;
+} HashEntry;
+
+typedef struct
+{
+    int count;
+    int capacity;
+    HashEntry* buckets;
+} HashTable;
+
+void htb_init(HashTable* table);
+bool htb_add(HashTable* table, ObjString* key, Value value);
+ObjString* htb_find_string(HashTable* table, const char* chars, int length,
+                           uint32_t hash);
+bool htb_delete(HashTable* table, ObjString* key);
+void htb_copy_table(HashTable* from, HashTable* to);
+Value* htb_get(HashTable* table, ObjString* key);
+void htb_free(HashTable* table);
+
+#endif  // HASH_TABLE_OPEN_H

--- a/include/memory.h
+++ b/include/memory.h
@@ -2,6 +2,7 @@
 #define MEMORY_H
 
 #include "common.h"
+#include "object.h"
 
 /* === Memory management === */
 
@@ -19,6 +20,7 @@
 
 void* mem_reallocate(void* pointer, size_t old_size, size_t new_size);
 void free_objects();
+void free_object(Obj* object);
 
 /* === Memory management === */
 

--- a/include/object.h
+++ b/include/object.h
@@ -21,6 +21,7 @@ struct ObjString
     int length;
     bool is_owning;  // Does it own its characters.
     char* chars;
+    uint32_t hash;
 };
 
 #define OBJ_TYPE(value) (AS_OBJ(value)->type)
@@ -33,10 +34,8 @@ static inline bool is_obj_type(Value value, ObjectType type)
     return IS_OBJ(value) && AS_OBJ(value)->type == type;
 }
 
-// Creates a string that owns its chars.
-ObjString* vle_owning_string(char* chars, int length);
-// Creates non-owning string that points into the source code.
-ObjString* vle_constant_string(char* chars, int length);
-void vle_print_object(Value value);
+ObjString* obj_create_string(char* chars, int length, bool is_owning);
+void obj_print_object(Value value);
+uint32_t obj_hash_string(const char* key, int length);
 
 #endif  // OBJECT_H

--- a/include/vm.h
+++ b/include/vm.h
@@ -2,6 +2,7 @@
 #define VM_H
 
 #include "chunk.h"
+#include "hash_table.h"
 
 static const int STACK_MAX = 256;
 
@@ -10,6 +11,7 @@ typedef struct
     Chunk* chunk;
     uint8_t* ip;
     vec_val_t stack;
+    HashTable strings;
 
     Obj* objects;
 } Vm;
@@ -33,6 +35,5 @@ void push_stack(Value value);
 Value pop_stack();
 
 /* === Stack manipulation === */
-
 
 #endif  // VM_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,2 @@
 target_sources(clox PRIVATE main.c chunk.c memory.c error.c debug.c
-        value.c vec.c vm.c compiler.c scanner.c object.c)
+        value.c vec.c vm.c compiler.c scanner.c object.c hash_table.c)

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -280,8 +280,8 @@ static void literal()
 
 static void string()
 {
-    emit_constant(OBJ_VAL(
-        vle_constant_string(g_parser.previous.start + 1, g_parser.previous.length - 2)));
+    emit_constant(OBJ_VAL(obj_create_string(g_parser.previous.start + 1,
+                                            g_parser.previous.length - 2, false)));
 }
 
 static void parse_precedence(Precedence precedence)

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -1,0 +1,174 @@
+#include "hash_table.h"
+#include "memory.h"
+
+#define TABLE_MAX_LOAD 0.75
+
+static void grow_table(HashTable* table, int capacity);
+static HashEntry* find_bucket(HashEntry* buckets, int capacity, ObjString* key);
+
+void htb_init(HashTable* table)
+{
+    table->count = 0;
+    table->capacity = 0;
+    table->buckets = NULL;
+}
+
+bool htb_add(HashTable* table, ObjString* key, Value value)
+{
+    if (table->count + 1 > table->capacity * TABLE_MAX_LOAD)
+    {
+        int capacity = GROW_CAPACITY(table->capacity);
+        grow_table(table, capacity);
+    }
+
+    HashEntry* bucket = find_bucket(table->buckets, table->capacity, key);
+    bool is_new = bucket->key == NULL;
+    if (is_new && IS_NIL(bucket->value))
+        table->count++;
+
+    bucket->key = key;
+    bucket->value = value;
+
+    return is_new;
+}
+
+ObjString* htb_find_string(HashTable* table, const char* chars, int length, uint32_t hash)
+{
+    if (table->count == 0)
+        return NULL;
+
+    uint32_t index = hash % table->capacity;
+    while (true)
+    {
+        HashEntry* bucket = &table->buckets[index];
+        if (bucket->key == NULL)
+        {
+            if (IS_NIL(bucket->value))
+                return NULL;
+        }
+        else if (bucket->key->length == length && bucket->key->hash == hash &&
+                 memcmp(bucket->key->chars, chars, length) == 0)
+        {
+            return bucket->key;
+        }
+
+        index = (index + 1) % table->capacity;
+    }
+}
+
+bool htb_delete(HashTable* table, ObjString* key)
+{
+    if (table->count == 0)
+        return false;
+
+    HashEntry* bucket = find_bucket(table->buckets, table->capacity, key);
+    if (bucket->key == NULL)
+        return false;
+
+    bucket->key = NULL;
+    bucket->value = BOOL_VAL(true);
+
+    return true;
+}
+
+void htb_copy_table(HashTable* from, HashTable* to)
+{
+    for (int i = 0; from->capacity; i++)
+    {
+        HashEntry* bucket = &from->buckets[i];
+        if (bucket->key != NULL)
+        {
+            htb_add(to, bucket->key, bucket->value);
+        }
+    }
+}
+
+Value* htb_get(HashTable* table, ObjString* key)
+{
+    if (table->count == 0)
+        return NULL;
+
+    HashEntry* bucket = find_bucket(table->buckets, table->capacity, key);
+    if (bucket->key == NULL)
+    {
+        return NULL;
+    }
+
+    return &bucket->value;
+}
+
+void htb_free(HashTable* table)
+{
+    FREE_ARRAY(HashEntry, table->buckets, table->count);
+    htb_init(table);
+}
+
+static void grow_table(HashTable* table, int capacity)
+{
+    // Allocate empty buckets array.
+    HashEntry* new_buckets = ALLOCATE(HashEntry, capacity);
+    for (int i = 0; i < capacity; i++)
+    {
+        new_buckets[i].key = NULL;
+        new_buckets[i].value = NIL_VAL;
+    }
+
+    if (table->count != 0)
+    {
+        table->count = 0;
+        // Copy the existing buckets to the new buckets array.
+        for (int i = 0; i < capacity; i++)
+        {
+            HashEntry* bucket = &table->buckets[i];
+            if (bucket->key == NULL)
+                continue;
+
+            HashEntry* dest = find_bucket(new_buckets, capacity, bucket->key);
+            dest->key = bucket->key;
+            dest->value = bucket->value;
+
+            table->count++;
+        }
+    }
+
+    FREE_ARRAY(HashEntry, table->buckets, table->capacity);
+
+    table->buckets = new_buckets;
+    table->capacity = capacity;
+}
+
+static HashEntry* find_bucket(HashEntry* buckets, int capacity, ObjString* key)
+{
+    uint32_t index = key->hash % capacity;
+    // Represents buckets that were deleted.
+    HashEntry* tombstone = NULL;
+    // It'll never go into an infinite loop here, because
+    // the table always has empty buckets (we grow it
+    // when it becomes 75% full).
+    while (true)
+    {
+        HashEntry* bucket = &buckets[index];
+        if (bucket->key == NULL)
+        {
+            if (IS_NIL(bucket->value))
+            {
+                // Empty bucket
+                return tombstone != NULL ? tombstone : bucket;
+            }
+            else
+            {
+                // Found a tombstone
+                if (tombstone == NULL)
+                    tombstone = bucket;
+            }
+        }
+        else if (bucket->key == key)
+        {
+            return bucket;
+        }
+
+        // The second modulo here wraps the index to the
+        // beginning of the array if it exceeds array's capacity.
+        index = (index + 1) % capacity;
+    }
+}

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,11 +1,8 @@
 #include <stdlib.h>
 
-#include "object.h"
 #include "vm.h"
 #include "error.h"
 #include "memory.h"
-
-static void free_object(Obj* object);
 
 void* mem_reallocate(void* pointer, size_t old_size, size_t new_size)
 {
@@ -36,7 +33,7 @@ void free_objects()
     }
 }
 
-static void free_object(Obj* object)
+void free_object(Obj* object)
 {
     switch (object->type)
     {

--- a/src/value.c
+++ b/src/value.c
@@ -18,7 +18,7 @@ void vle_print_value(Value value)
             printf("nil");
             break;
         case VAL_OBJ:
-            vle_print_object(value);
+            obj_print_object(value);
             break;
         default:
             DEBUG_ERROR("Not every error case was handled.");
@@ -45,10 +45,7 @@ bool vle_is_equal(Value a, Value b)
             return true;
         case VAL_OBJ:
         {
-            ObjString* a_str = AS_STRING(a);
-            ObjString* b_str = AS_STRING(b);
-            return a_str->length == b_str->length &&
-                   memcmp(a_str, b_str, a_str->length) == 0;
+            return AS_OBJ(a) == AS_OBJ(b);
         }
         default:
             DEBUG_ERROR("Not every case was handled.");

--- a/src/vm.c
+++ b/src/vm.c
@@ -29,6 +29,7 @@ void vm_init_vm()
 {
     vec_init(&g_vm.stack);
     g_vm.objects = NULL;
+    htb_init(&g_vm.strings);
 }
 
 InterpreterResult vm_interpret(const char* source)
@@ -55,6 +56,7 @@ void vm_free_vm()
 {
     vec_deinit(&g_vm.stack);
     free_objects();
+    htb_free(&g_vm.strings);
 }
 
 static InterpreterResult run()
@@ -256,6 +258,14 @@ static void concatenate()
     memcpy(chars + a->length, b->chars, b->length);
     chars[length] = '\0';
 
-    ObjString* result = vle_owning_string(chars, length);
+    ObjString* result = obj_create_string(chars, length, true);
+//    Value* string = htb_get(&g_vm.strings, result);
+//    if (string != NULL)
+//    {
+//        push_stack(OBJ_VAL(string));
+//    }
+//    else
+//    {
+//    }
     push_stack(OBJ_VAL(result));
 }


### PR DESCRIPTION
Implemented a hash table that is currently used for string interning.
String comparison is faster now, because of the strings are interned.
Two different string allocation functions were replaced with one.
`free_object()` from `memory.c` is now public.